### PR TITLE
Enable by scope and allow home page match

### DIFF
--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -13,12 +13,14 @@ namespace bitExpert\ForceCustomerLogin\Controller;
 use \bitExpert\ForceCustomerLogin\Api\Controller\LoginCheckInterface;
 use \bitExpert\ForceCustomerLogin\Api\Repository\WhitelistRepositoryInterface;
 use \bitExpert\ForceCustomerLogin\Model\ResourceModel\WhitelistEntry\Collection;
+use Magento\Config\Test\Handler\ConfigData\ConfigDataInterface;
 use \Magento\Framework\App\Action\Action;
 use \Magento\Framework\App\Action\Context;
 use \bitExpert\ForceCustomerLogin\Model\Session;
 use \Magento\Framework\UrlInterface;
 use \Magento\Framework\App\DeploymentConfig;
 use \Magento\Backend\Setup\ConfigOptionsList as BackendConfigOptionsList;
+use \Magento\Framework\App\Config\ScopeConfigInterface;
 
 /**
  * Class LoginCheck
@@ -43,6 +45,10 @@ class LoginCheck extends Action implements LoginCheckInterface
      */
     protected $whitelistRepository;
     /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+    /**
      * @var string
      */
     protected $targetUrl;
@@ -50,22 +56,25 @@ class LoginCheck extends Action implements LoginCheckInterface
     /**
      * Creates a new {@link \bitExpert\ForceCustomerLogin\Controller\LoginCheck}.
      *
-     * @param Context $context
-     * @param Session $session
-     * @param DeploymentConfig $deploymentConfig
+     * @param Context                      $context
+     * @param Session                      $session
+     * @param DeploymentConfig             $deploymentConfig
      * @param WhitelistRepositoryInterface $whitelistRepository
-     * @param string $targetUrl
+     * @param ScopeConfigInterface         $scopeConfig
+     * @param string                       $targetUrl
      */
     public function __construct(
         Context $context,
         Session $session,
         DeploymentConfig $deploymentConfig,
         WhitelistRepositoryInterface $whitelistRepository,
+        ScopeConfigInterface $scopeConfig,
         $targetUrl
     ) {
         $this->session = $session;
         $this->deploymentConfig = $deploymentConfig;
         $this->whitelistRepository = $whitelistRepository;
+        $this->scopeConfig = $scopeConfig;
         $this->targetUrl = $targetUrl;
         parent::__construct($context);
     }
@@ -77,6 +86,11 @@ class LoginCheck extends Action implements LoginCheckInterface
     {
         $url = $this->_url->getCurrentUrl();
         $path = \parse_url($url, PHP_URL_PATH);
+
+        // if not enabled for site, no redirect needed
+        if ($this->scopeConfig->getValue('customer/startup/force_login','store') != 1) {
+            return;
+        }
 
         // current path is already pointing to target url, no redirect needed
         if ($this->targetUrl === $path) {

--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -102,7 +102,7 @@ class LoginCheck extends Action implements LoginCheckInterface
 
         // check if current url is a match with one of the ignored urls
         foreach ($extendedIgnoreUrls as $ignoreUrl) {
-            if (\preg_match(\sprintf('#^.*%s/?.*$#i', $this->quoteRule($ignoreUrl)), $path)) {
+            if (\preg_match(\sprintf('#^%s/?$#i', $this->quoteRule($ignoreUrl)), $path)) {
                 return;
             }
         }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="customer">
+            <group id="startup">
+                <field id="force_login" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Force Login</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Customer will be redirected if not logged in or on whitelisted page.</comment>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <customer>
+            <startup>
+                <force_login>1</force_login>
+            </startup>
+        </customer>
+    </default>
+</config>


### PR DESCRIPTION
To fix #54 and #55, added a system config option at all scopes to enable/disable extension
Also, changed the matching regex to be more strict. The current prefix-style version of the regex makes it impossible to whitelist the homepage.

I hadn't seen the presence of tests until after I made these improvements.