### PR TITLE
Updated resource ACL

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -8,7 +8,7 @@
         <section id="bitExpert_ForceCustomerLogin" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Configuration</label>
             <tab>bitExpert_ForceCustomerLogin</tab>
-            <resource>bitExpert::ForceCustomerLogin</resource>
+            <resource>BitExpert_ForceCustomerLogin::bitexpert_force_customer_login_manage</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General</label>
                 <field id="enabled" translate="label comment" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
After installation exception being thrown when trying to access store configuration:

```ssh
Invalid XML in file {...}/bitexpert/magento2-force-customer-login/etc/adminhtml/system.xml:
Element 'resource': [facet 'pattern'] The value 'bitExpert::ForceCustomerLogin' is not accepted by the pattern '([A-Z]+[a-zA-Z0-9]{1,}){1,}_[A-Z]+[A-Z0-9a-z]{1,}::[A-Za-z_0-9]{1,}'. Line: 11
Element 'resource': 'bitExpert::ForceCustomerLogin' is not a valid value of the atomic type 'typeAclResourceId'. Line: 11
```

Appears to be due to incorrect value for resource