### PR TITLE
Don't store AJAX requests as after login url

### DIFF
--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -130,7 +130,9 @@ class LoginCheck extends Action implements LoginCheckInterface
             }
         }
 
-        $this->session->setAfterLoginReferer($path);
+        if (!$this->isAjaxRequest()) {
+            $this->session->setAfterLoginReferer($path);
+        }
 
         $this->response->setNoCacheHeaders();
         $this->response->setRedirect($this->getRedirectUrl($targetUrl));
@@ -147,6 +149,21 @@ class LoginCheck extends Action implements LoginCheckInterface
             self::MODULE_CONFIG_TARGET,
             ScopeInterface::SCOPE_STORE
         );
+    }
+
+    /**
+     * Check if a request is AJAX request
+     *
+     * @return bool
+     */
+    protected function isAjaxRequest()
+    {
+        if (method_exists($this->_request, 'isAjax') && is_callable([$this->_request, 'isAjax'])) {
+            /** @uses \Magento\Framework\App\Request\Http::isAjax() */
+            return $this->_request->isAjax();
+        }
+
+        return (bool) $this->_request->getParam('isAjax');
     }
 
     /**

--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -158,8 +158,7 @@ class LoginCheck extends Action implements LoginCheckInterface
      */
     protected function isAjaxRequest()
     {
-        if (method_exists($this->_request, 'isAjax') && is_callable([$this->_request, 'isAjax'])) {
-            /** @uses \Magento\Framework\App\Request\Http::isAjax() */
+        if ($this->_request instanceof \Magento\Framework\App\Request\Http) {
             return $this->_request->isAjax();
         }
 

--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -161,8 +161,10 @@ class LoginCheck extends Action implements LoginCheckInterface
         if ($this->_request instanceof \Magento\Framework\App\Request\Http) {
             return $this->_request->isAjax();
         }
-
-        return (bool) $this->_request->getParam('isAjax');
+        if ($this->_request->getParam('ajax') || $this->_request->getParam('isAjax')) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -156,7 +156,7 @@ class LoginCheck extends Action implements LoginCheckInterface
      *
      * @return bool
      */
-    protected function isAjaxRequest()
+    private function isAjaxRequest()
     {
         if ($this->_request instanceof \Magento\Framework\App\Request\Http) {
             return $this->_request->isAjax();


### PR DESCRIPTION
Was working with another 3-party module that made a AJAX call after the login page was loaded
This made it so that after logging in the customer would be redirected to a API endpoint not made to handle HTML requests.

This pull request make it so that only non AJAX request is saved to the session as `after_login_referer`

An alternative way to solve the above mentioned problem would be to check the requests `Referer` header to see if the AJAX request was made from the login page and use that to determine if the request URL should be saved to  `after_login_referer` or not