### PR TITLE
#117 Fixes for multiple stores with store name in path

### DIFF
--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -21,6 +21,7 @@ use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Response\Http as ResponseHttp;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Class LoginCheck
@@ -37,6 +38,10 @@ class LoginCheck extends Action implements LoginCheckInterface
      * @var Session
      */
     private $session;
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
     /**
      * @var ScopeConfigInterface
      */
@@ -64,6 +69,7 @@ class LoginCheck extends Action implements LoginCheckInterface
      * @param Context $context
      * @param CustomerSession $customerSession
      * @param Session $session
+     * @param StoreManagerInterface $storeManager
      * @param ScopeConfigInterface $scopeConfig
      * @param WhitelistRepositoryInterface $whitelistRepository
      * @param StrategyManager $strategyManager
@@ -74,6 +80,7 @@ class LoginCheck extends Action implements LoginCheckInterface
         Context $context,
         CustomerSession $customerSession,
         Session $session,
+        StoreManagerInterface $storeManager,
         ScopeConfigInterface $scopeConfig,
         WhitelistRepositoryInterface $whitelistRepository,
         StrategyManager $strategyManager,
@@ -82,6 +89,7 @@ class LoginCheck extends Action implements LoginCheckInterface
     ) {
         $this->customerSession = $customerSession;
         $this->session = $session;
+        $this->storeManager = $storeManager;
         $this->scopeConfig = $scopeConfig;
         $this->whitelistRepository = $whitelistRepository;
         $this->strategyManager = $strategyManager;
@@ -147,6 +155,15 @@ class LoginCheck extends Action implements LoginCheckInterface
     }
 
     /**
+     * @return string
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    private function getBaseUrl()
+    {
+        return $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB, true);
+    }
+
+    /**
      * Check if a request is AJAX request
      *
      * @return bool
@@ -170,7 +187,7 @@ class LoginCheck extends Action implements LoginCheckInterface
     {
         return \sprintf(
             '%s%s',
-            $this->_url->getBaseUrl(),
+            $this->getBaseUrl(),
             $targetUrl
         );
     }


### PR DESCRIPTION
Fixes issue #117 with multiple stores and domains having store name in path.

As shown in the screenshots below, the URL is now correctly resolved to the store's configured secure base URL. For this to work properly, the general configuration to add store Code to Urls must be enabled.

![forcelogin-fix117-3](https://user-images.githubusercontent.com/5824556/42134787-4a5d2e44-7d42-11e8-9fc4-689db91549a4.png)


![forcelogin-fix117-1](https://user-images.githubusercontent.com/5824556/42134713-8d46afc4-7d41-11e8-86ff-0d6ec66888a4.png)
![forcelogin-fix117-2](https://user-images.githubusercontent.com/5824556/42134714-8d6055aa-7d41-11e8-9ee3-a9c1df133e3c.png)

Best regards