### PR TITLE
Fix problem with module path in Docker container

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,4 +1,4 @@
 #!/bin/bash
 bin/cli rm /dist/bitexpert_forcecustomerlogin.zip
-bin/cli bash -c 'cd /var/www/BitExpert/ForceCustomerLogin && zip -r /dist/bitexpert_forcecustomerlogin.zip . -x *.git* *.github* *.idea* bin/* env/* dist/* vendor/* .coveralls.yml .travis.yml auth.json.enc docker-compose.yml validate_m2_package.php'
-bin/cli /var/www/BitExpert/ForceCustomerLogin/validate_m2_package.php /dist/bitexpert_forcecustomerlogin.zip
+bin/cli bash -c 'cd /var/www/html/BitExpert/ForceCustomerLogin && zip -r /dist/bitexpert_forcecustomerlogin.zip . -x *.git* *.github* *.idea* bin/* env/* dist/* vendor/* .coveralls.yml .travis.yml auth.json.enc docker-compose.yml validate_m2_package.php'
+bin/cli /var/www/html/BitExpert/ForceCustomerLogin/validate_m2_package.php /dist/bitexpert_forcecustomerlogin.zip

--- a/bin/setup
+++ b/bin/setup
@@ -52,10 +52,10 @@ echo "Clearing the cache for good measure..."
 bin/clinotty bin/magento cache:flush
 
 echo "Installing Force Login Composer module..."
-bin/rootnotty chmod +x bin/magento /var/www/BitExpert/ForceCustomerLogin/validate_m2_package.php
+bin/rootnotty chmod +x bin/magento /var/www/html/BitExpert/ForceCustomerLogin/validate_m2_package.php
 bin/rootnotty chown -R app.app /dist
 bin/clinotty composer config minimum-stability dev
-bin/clinotty composer config "repositories.bitexpert/magento2-force-customer-login" '{"type": "path", "url": "/var/www/BitExpert/ForceCustomerLogin/", "options": {"symlink": true}}'
+bin/clinotty composer config "repositories.bitexpert/magento2-force-customer-login" '{"type": "path", "url": "/var/www/html/BitExpert/ForceCustomerLogin/", "options": {"symlink": true}}'
 bin/clinotty composer require bitexpert/magento2-force-customer-login:*
 
 echo "Enabling Force Login module..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,35 @@ services:
     volumes: &appvolumes
       - ~/.composer:/var/www/.composer
       - ~/.composer/auth.json:/var/www/html/auth.json
-      - ./:/var/www/BitExpert/ForceCustomerLogin/
+      - ./Api:/var/www/html/bitExpert/ForceCustomerLogin/Api
+      - ./Block:/var/www/html/bitExpert/ForceCustomerLogin/Block
+      - ./Controller:/var/www/html/bitExpert/ForceCustomerLogin/Controller
+      - ./etc:/var/www/html/bitExpert/ForceCustomerLogin/etc
+      - ./Helper:/var/www/html/bitExpert/ForceCustomerLogin/Helper
+      - ./Model:/var/www/html/bitExpert/ForceCustomerLogin/Model
+      - ./Plugin:/var/www/html/bitExpert/ForceCustomerLogin/Plugin
+      - ./Repository:/var/www/html/bitExpert/ForceCustomerLogin/Repository
+      - ./Setup:/var/www/html/bitExpert/ForceCustomerLogin/Setup
+      - ./Ui:/var/www/html/bitExpert/ForceCustomerLogin/Ui
+      - ./Validator:/var/www/html/bitExpert/ForceCustomerLogin/Validator
+      - ./view:/var/www/html/bitExpert/ForceCustomerLogin/view
+      - ./registration.php:/var/www/html/bitExpert/ForceCustomerLogin/registration.php
+      - ./Api:/var/www/html/BitExpert/ForceCustomerLogin/Api
+      - ./Block:/var/www/html/BitExpert/ForceCustomerLogin/Block
+      - ./Controller:/var/www/html/BitExpert/ForceCustomerLogin/Controller
+      - ./etc:/var/www/html/BitExpert/ForceCustomerLogin/etc
+      - ./Helper:/var/www/html/BitExpert/ForceCustomerLogin/Helper
+      - ./Model:/var/www/html/BitExpert/ForceCustomerLogin/Model
+      - ./Plugin:/var/www/html/BitExpert/ForceCustomerLogin/Plugin
+      - ./Repository:/var/www/html/BitExpert/ForceCustomerLogin/Repository
+      - ./Setup:/var/www/html/BitExpert/ForceCustomerLogin/Setup
+      - ./Ui:/var/www/html/BitExpert/ForceCustomerLogin/Ui
+      - ./Validator:/var/www/html/BitExpert/ForceCustomerLogin/Validator
+      - ./view:/var/www/html/BitExpert/ForceCustomerLogin/view
+      - ./composer.json:/var/www/html/BitExpert/ForceCustomerLogin/composer.json
+      - ./composer.lock:/var/www/html/BitExpert/ForceCustomerLogin/composer.lock
+      - ./registration.php:/var/www/html/BitExpert/ForceCustomerLogin/registration.php
+      - ./validate_m2_package.php:/var/www/html/BitExpert/ForceCustomerLogin/validate_m2_package.php
       - ./dist:/dist
       - appdata:/var/www/html
       - sockdata:/sock


### PR DESCRIPTION
Since the module used to reside outside of /var/www/html Magento had an issue loading the views. The module is moved to /var/www/html/BitExpert/ForceCustomerLogin now to fix this issue.