### PR TITLE
added /stores/store/switch and /stores/store/redirect to the whitelist

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -80,6 +80,10 @@ class UpgradeData implements UpgradeDataInterface
             $this->runUpgrade304($setup);
         }
 
+        if (version_compare($context->getVersion(), '3.0.5', '<')) {
+            $this->runUpgrade305($setup);
+        }
+
         $setup->endSetup();
     }
 
@@ -248,6 +252,30 @@ class UpgradeData implements UpgradeDataInterface
                 0,
                 'Varnish ESI url',
                 '/page_cache/block/esi/blocks'
+            ),
+        ];
+
+        $setup->getConnection()->insertMultiple(
+            $setup->getTable('bitexpert_forcelogin_whitelist'),
+            $whitelistEntries
+        );
+    }
+
+    /**
+     * @param ModuleDataSetupInterface $setup
+     */
+    private function runUpgrade305(ModuleDataSetupInterface $setup)
+    {
+        $whitelistEntries = [
+            $this->getWhitelistEntryAsArray(
+                0,
+                'Store-Switcher Redirect',
+                '/stores/store/redirect'
+            ),
+            $this->getWhitelistEntryAsArray(
+                0,
+                'Store-Switcher Switch',
+                '/stores/store/switch'
             ),
         ];
 

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,7 +11,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="BitExpert_ForceCustomerLogin" setup_version="3.0.4">
+    <module name="BitExpert_ForceCustomerLogin" setup_version="3.0.5">
         <sequence>
             <module name="Magento_Customer"/>
         </sequence>


### PR DESCRIPTION
fixes #164 

store switching uses these 2 urls and is save to us for unauthenticated users.

unit-tests not needed