### PR TITLE
Improve menu placement: fix compatibility with B2B.

### DIFF
--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -12,14 +12,14 @@
              title="Whitelist"
              module="BitExpert_ForceCustomerLogin"
              parent="BitExpert_ForceCustomerLogin::bitexpert_force_login_whitelist"
-             sortOrder="55"
+             sortOrder="10"
              action="ForceCustomerLogin/Manage"
              resource="BitExpert_ForceCustomerLogin::bitexpert_force_customer_login_manage"/>
 
         <add id="BitExpert_ForceCustomerLogin::bitexpert_force_login_whitelist"
              title="Force Customer Login"
-             module="Magento_Backend"
-             sortOrder="50"
+             module="BitExpert_ForceCustomerLogin"
+             sortOrder="100"
              parent="Magento_Customer::customer"
              resource="BitExpert_ForceCustomerLogin::bitexpert_force_customer_login_manage"/>
     </menu>


### PR DESCRIPTION
Hi!

On Magento with installed B2B menu is shown in the middle (because Order is set to 55, Magento Companies adds own menu  with sortOrder=60). As result, menu looks not clear:
![Screenshot at Jan 17 12-34-08](https://user-images.githubusercontent.com/5318027/72601039-b61abc00-3925-11ea-9243-a47ac1312d05.png)

In PR  menu sort order is updated  to 10, and into menu to 10. 
Do you need the same thing for 3.x release?

Thank you

