### PR TITLE
force login in store redirects to default login

### DIFF
--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -227,7 +227,7 @@ class LoginCheck implements LoginCheckInterface
     {
         $secure = $this->getForceSecureRedirectOption();
         $secure = ($secure === true) ? true : null;
-        return $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_WEB, $secure);
+        return $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_LINK, $secure);
     }
 
     /**


### PR DESCRIPTION
Using `UrlInterface::URL_TYPE_WEB`  redirects to default login whereas `UrlInterface::URL_TYPE_LINK` redirects to store specific login which creates a problem when hosting multiply sub-directory stores.