### PR TITLE
Fix for: Homepage Redirect After Login Leads To incorrect url #184

### DIFF
--- a/Controller/LoginCheck.php
+++ b/Controller/LoginCheck.php
@@ -166,7 +166,9 @@ class LoginCheck implements LoginCheckInterface
         }
 
         // Set Url To redirect ,using standard method of magento
-        $this->customerSession->setBeforeAuthUrl($url);
+        if (strpos($url, 'customer/section/load') == false && strpos($url, '_=') == false) {
+            $this->customerSession->setBeforeAuthUrl($url);
+        }
 
         // check if current url is a match with one of the ignored urls
         /** @var \BitExpert\ForceCustomerLogin\Model\WhitelistEntry $rule */


### PR DESCRIPTION
This PR fixes the issue https://github.com/bitExpert/magento2-force-login/issues/184 reported by multiple users where a customer is being redirected to customer/section/load when this controller is being called right after logging in.

This fix prevents the LoginCheck controller to use those async controllers as referrers, otherwise, the customer will be redirected to a blank page with JSON content.